### PR TITLE
Feat: Lay state feed in component FrontPage

### DIFF
--- a/src/components/FrontPage.js
+++ b/src/components/FrontPage.js
@@ -1,3 +1,14 @@
+import { useState } from 'react';
+
+import Feed from './FrontPage/Feed';
+
+/** Only do pages move by scroll
+ * @page Home - linked motion with Profile
+ * @page Profile - linked motion with Home
+ * @page Feed
+ */
 export default function FrontPage() {
-  return <div className='front-page' />;
+  // eslint-disable-next-line no-unused-vars
+  const [feed, setFeed] = useState(<Feed />);
+  return <div className='front-page'>{feed}</div>;
 }


### PR DESCRIPTION
And we have to consider how to make motion between Home and Profile, and if it is better to divide both pages or express in a page. For now, it should be first above rest to complete marking up Feed.

Related to: #27 #17